### PR TITLE
Fix map definitions for Mission Pack 3: The Ultimate Challenge.

### DIFF
--- a/MapInfo.txt
+++ b/MapInfo.txt
@@ -1053,7 +1053,7 @@ map SD312 "$SD312"
 	par = 270
 	next = SD313
 	levelnum = 912
-	secretnext = RTD20
+	secretnext = SD320
 }
 
 map SD313 "$SD313"
@@ -1108,8 +1108,8 @@ map SD319 "$SD319"
 {
 	music = XJAZNAZI
 	par = 0
-	next = RTD05
-	secretnext = RTD05
+	next = SD305
+	secretnext = SD305
 	levelnum = 919
 }
 


### PR DESCRIPTION
In Wolfenstein 3D TC 2.0 these wrong map definitions resulted in wrong transition behaviour (Exiting from first secret level crashed the game and secret exit in floor 12 not worked properly).