### PR TITLE
Player bobbing fixes.

### DIFF
--- a/Scripts/Actors/Player.zs
+++ b/Scripts/Actors/Player.zs
@@ -39,6 +39,7 @@ class WolfPlayer : DoomPlayer
 		Player.DisplayName "BJ";
 		Player.Face "WLF";
 		Player.ForwardMove 1.3, 1.3;
+		Player.ViewBob 0.125;
 		Player.MaxHealth 100;
 		Player.SideMove 1.3, 1.3;
 		Player.StartItem "WolfPistol";
@@ -136,6 +137,11 @@ class WolfPlayer : DoomPlayer
 	override void PlayerThink()
 	{
 		Super.PlayerThink();
+
+		if (!(player.cheats & CF_PREDICTING))
+		{
+			ViewBob = Default.ViewBob * CVar.GetCVar("g_viewbobscale", player).GetFloat();
+		}
 
 		if (player.playerstate != PST_DEAD && !(player.cheats & CF_PREDICTING))
 		{

--- a/Scripts/Actors/Weapons.zs
+++ b/Scripts/Actors/Weapons.zs
@@ -36,6 +36,7 @@ class ClassicWeapon : Weapon
 		Obituary "";
 		Inventory.PickupMessage "";
 		Weapon.YAdjust 2.0;
+		Weapon.BobSpeed 2.0;
 	}
 
 	States


### PR DESCRIPTION
- Turn down the player's ViewBob to a value that matches BJ's movement speed
- Also add a custom bobbing speed to the base weapon to match the above
- Multiply the view bobbing with g_viewbobscale, so that when the "Doom viewbobbing" setting is turned off, there will be absolutely no bobbing, emulating the original game