### PR TITLE
Fix viewbob scale and logic.

### DIFF
--- a/Scripts/Actors/Player.zs
+++ b/Scripts/Actors/Player.zs
@@ -97,6 +97,8 @@ class WolfPlayer : DoomPlayer
 		CVar momentum = CVar.FindCVar("g_momentum");
 		CVar bobscale = CVar.GetCVar("g_viewbobscale", player);
 
+		ViewBob = default.ViewBob * (bobscale && bobscale.GetFloat() != 0);
+
 		if ((!momentum || !momentum.GetInt()) && pos.z == floorz)
 		{
 			// Stop screen bobbing if the player is stopped or if no weapon bob is enabled

--- a/Scripts/Actors/Weapons.zs
+++ b/Scripts/Actors/Weapons.zs
@@ -123,8 +123,8 @@ class ClassicWeapon : Weapon
 			CVar bobscale = CVar.GetCVar("g_viewbobscale", owner.player);
 			if (bobscale)
 			{
-				bobrangex = Default.bobrangex * bobscale.GetFloat();
-				bobrangey = Default.bobrangey * bobscale.GetFloat();
+				bobrangex = Default.bobrangex * bobscale.GetFloat() / WeaponScaleY;
+				bobrangey = Default.bobrangey * bobscale.GetFloat() / WeaponScaleY;
 			}
 
 			SetYPosition();


### PR DESCRIPTION
There were two issues with bobbing:
- There would still be a little bit of view bobbing even though `g_viewbobscale` was 0.
- The weapon bobbing scale was super exaggerated when g_viewbobscale was non-zero.

This PR should fix both of the above issues.

Edit: I probably should have checked the existing PR's to see https://github.com/AFADoomer/Wolf3D-TC-3.0/pull/32. I will leave this here nevertheless as an alternative approach.