### PR TITLE
Improve faithfulness to original's frame timings.

### DIFF
--- a/Scripts/Actors/Enemies.zs
+++ b/Scripts/Actors/Enemies.zs
@@ -706,6 +706,18 @@ class ClassicNazi : ClassicBase
 	FlagDef LongDeath:flags, 0;
 	FlagDef Patrolling:flags, 1;
 
+	// [DenisBelmondo]: in OG Doom (p_inter.c > P_KillMobj), there is a random
+	// amount of tics between 0 and 3 subtracted from the death animation. This
+	// behavior, of course carries in GZDoom, but Wolf3D never had this
+	// behavior. This is a quick hack that fixes it because evidently, calling
+	// A_SetTics on the first death state doesn't do the trick.
+
+	override void Die(Actor source, Actor inflictor, int dmgflags, Name meansofdeath)
+	{
+		super.Die(source, inflictor, dmgflags, meansofdeath);
+		tics = deathtics;
+	}
+
 	Default
 	{
 		ClassicNazi.DeathTics 8;
@@ -761,14 +773,11 @@ class ClassicNazi : ClassicBase
 			"####" J 5 A_Pain;
 			"####" A 0 A_Jump(256, "Chase");
 		Death:
-			"####" A 0 {
-				A_DeathScream();
-				A_DeathDrop();
-			}
-			"####" K 7 A_SetTics(deathtics - 1);
+			"####" A 0 A_DeathDrop();
+			"####" K 8 A_SetTics(deathtics);
 		Death.Resume:
-			"####" L 8 A_SetTics(deathtics);
-			"####" M 7 A_SetTics(deathtics - 1);
+			"####" L 7 { A_SetTics(deathtics - 1); A_DeathScream(); }
+			"####" M 8 A_SetTics(deathtics);
 			"####" N 0 { if (bLongDeath) { A_SetTics(deathtics); } }
 		Dead:
 			"####" N -1 { if (bLongDeath) { frame = 14; } }
@@ -876,9 +885,10 @@ class Dog : ClassicNazi
 			"####" EA 5;
 			Goto Chase;
 		Death:
-			"####" A 0 A_DeathScream;
+			"####" H 8 A_DeathDrop();
 		Death.Resume:
-			"####" HIJ 5;
+			"####" I 7 A_DeathScream();
+			"####" J 8;
 		Dead:
 			"####" K -1;
 			Stop;
@@ -945,7 +955,7 @@ class Guard : ClassicNazi
 			"####" # 0 A_Stop;
 			"####" GH 10 A_FaceTarget;
 		Attack:
-			"####" I 8 A_NaziShoot();
+			"####" I 10 A_NaziShoot();
 			Goto Chase;
 	}
 }

--- a/Scripts/Actors/Weapons.zs
+++ b/Scripts/Actors/Weapons.zs
@@ -123,8 +123,8 @@ class ClassicWeapon : Weapon
 			CVar bobscale = CVar.GetCVar("g_viewbobscale", owner.player);
 			if (bobscale)
 			{
-				bobrangex = Default.bobrangex * bobscale.GetFloat();
-				bobrangey = Default.bobrangey * bobscale.GetFloat();
+				bobrangex = Default.bobrangex * bobscale.GetFloat() / WeaponScaleY;
+				bobrangey = Default.bobrangey * bobscale.GetFloat() / WeaponScaleY;
 			}
 
 			SetYPosition();
@@ -321,8 +321,9 @@ class WolfKnife : ClassicWeapon
 			Loop;
 		Fire:
 			"####" B 3;
-			"####" C 3 A_WolfPunch(GameHandler.WolfRandom() >> (invoker.adrenaline ? 1 : 4), 1, 0, "WolfPuff", meleesound:"weapons/wknife", misssound:"weapons/wknife");
-			"####" DE 3;
+			"####" C 3;
+			"####" D 3 A_WolfPunch(GameHandler.WolfRandom() >> (invoker.adrenaline ? 1 : 4), 1, 0, "WolfPuff", meleesound:"weapons/wknife", misssound:"weapons/wknife");
+			"####" E 3;
 			"####" A 0 A_Jump(256, "Refire");
 	}
 
@@ -459,8 +460,9 @@ class WolfPistol : ClassicWeapon
 			Loop;
 		Fire:
 			"####" B 3;
-			"####" C 3 Bright A_FireGun(2.0);
-			"####" DE 3;
+			"####" C 3 Bright;
+			"####" D 3 A_FireGun(2.0);
+			"####" E 3;
 			"####" A 0 A_Jump(256, "Refire");
 	}
 }
@@ -491,8 +493,8 @@ class WolfMachineGun : ClassicWeapon
 		Fire:
 			"####" B 3;
 		Hold:
-			"####" C 3 Bright A_FireGun(3.0);
-			"####" D 3;
+			"####" C 3 Bright;
+			"####" D 3 A_FireGun(3.0);
 			"####" E 3 A_ReFire();
 			"####" A 0 A_Jump(256, "Ready");
 	}
@@ -525,7 +527,9 @@ class WolfChaingun : ClassicWeapon
 		Fire:
 			"####" B 3;
 		Hold:
-			"####" CD 3 Bright A_FireGun(4.0);
+			"####" C 3 Bright;
+			"####" D 3 Bright A_FireGun(4.0);
+			"####" "#" 0 A_FireGun(4.0);
 			"####" E 3 A_ReFire();
 			"####" A 0 A_Jump(256, "Ready");
 	}


### PR DESCRIPTION
This is a small adjustment that makes the game feel a lot more like the original. In short:
- Weapons call their fire function a tic _after_ the muzzle flash/visual feedback.
- `ClassicNazi`'s call A_Scream on the second state of their death sequence.
- Brownshirts linger on their muzzle flash frame for 10 tics instead of 8.
- `ClassicNazi`'s no longer have their first death state randomly made 0-3 tics faster.