### PR TITLE
Add +NOEXTREMEDEATH to WolfPuff.

### DIFF
--- a/Scripts/Actors/Weapons.zs
+++ b/Scripts/Actors/Weapons.zs
@@ -175,6 +175,7 @@ class WolfPuff : BulletPuff
 {
 	Default
 	{
+		+NOEXTREMEDEATH
 		+ROLLSPRITE
 		Alpha 1.0;
 	}


### PR DESCRIPTION
This PR adds the `NOEXTREMEDEATH` flag to `WolfPuff`. Rationale: many blood special FX mods check to see if an actor is in their XDeath state to decide whether or not to spawn gibs. This should increase compatibility with these types of mods as well as ensuring custom monsters that have XDeath states do not enter them when being killed with the default Wolf3D weapons. 