### PR TITLE
Fix weapon offsets when status bar is visible.

### DIFF
--- a/Scripts/Actors/Weapons.zs
+++ b/Scripts/Actors/Weapons.zs
@@ -23,6 +23,8 @@
 // Wolf3D Weapons
 class ClassicWeapon : Weapon
 {
+	const WEAPON_OFFSET_Y = 4.8;
+
 	int flags;
 
 	FlagDef DOGRIN:flags, 0;
@@ -87,7 +89,7 @@ class ClassicWeapon : Weapon
 		if (tgt)
 		{
 			dmg = GameHandler.WolfRandom();
-			
+
 			if (ClassicBase(tgt))
 			{
 				if (!ClassicBase(tgt).bActive)
@@ -137,7 +139,7 @@ class ClassicWeapon : Weapon
 		let psp = owner.player.GetPSprite(PSP_WEAPON);
 		if (!psp) { return; }
 
-		if (screenblocks < 11) { psp.y = WEAPONTOP - 15.0 * max(st_scale, 0) / WeaponScaleY; }
+		if (screenblocks < 11) { psp.y = WEAPONTOP - WEAPON_OFFSET_Y; }
 		else { psp.y = WEAPONTOP + 6.0 / WeaponScaleY; }
 	}
 
@@ -468,7 +470,7 @@ class WolfPistol : ClassicWeapon
 			"####" A 0 A_Jump(256, "Refire");
 	}
 }
- 
+
 class WolfMachineGun : ClassicWeapon
 {
 	Default
@@ -500,7 +502,7 @@ class WolfMachineGun : ClassicWeapon
 			"####" E 3 A_ReFire();
 			"####" A 0 A_Jump(256, "Ready");
 	}
-} 
+}
 
 class WolfChaingun : ClassicWeapon
 {


### PR DESCRIPTION
Previously, weapons were too low on the screen when the status bar was visible; this should fix that. There is a magic constant involved, however.