### PR TITLE
Shrink down BJ's player sprites a little to match common Nazi sizes

### DIFF
--- a/Scripts/Actors/Player.zs
+++ b/Scripts/Actors/Player.zs
@@ -38,6 +38,7 @@ class WolfPlayer : PlayerPawn
 		PainChance 255;
 		Radius 16;
 		Speed 1;
+		Scale 0.93;
 
 		Player.DisplayName "BJ";
 		Player.Face "WLF";


### PR DESCRIPTION
So one problem with the new player sprites, as nice as they are (in my opinion) is that they make BJ look significantly bigger than the common enemies in the game.

I'm not sure what's the policy here when it comes to using art assets that's not 1:1 in pixel ratio, but my argument for this is that the shrinking is not _too_ noticeable, pixel-wise, plus these sprites in particular are only seen in multiplayer, which; let's be honest here, I don't think _too many_ people would play or even notice... but for those who _do_ notice, I think a bit of sizing consistency here is nice.

Following images show before and after shrinking.

<img width="784" height="411" alt="Screenshot_Wolf3D_20260425_171358" src="https://github.com/user-attachments/assets/d72e9bdd-549e-4cb2-91f8-2e9c9e291143" />

<img width="784" height="411" alt="Screenshot_Wolf3D_20260425_171756" src="https://github.com/user-attachments/assets/aa6a84da-edd5-457b-b01e-31d044dedaa3" />
